### PR TITLE
Update logging Level and allow Sub Classing

### DIFF
--- a/rules/src/main/java/ch/maxant/rules/Engine.java
+++ b/rules/src/main/java/ch/maxant/rules/Engine.java
@@ -436,12 +436,18 @@ public class Engine {
 			}
 			
 			Object o = MVEL.executeExpression(r.getCompiled(), vars);
-			String msg = r.getRule().getFullyQualifiedName() + "-{" + r.getRule().getExpression() + "}";
 			if(String.valueOf(o).equals("true")){
 				matchingRules.add(r.getRule());
-                if(log.isLoggable(Level.INFO)) log.info("matched: " + msg);
+				if(log.isLoggable(Level.FINE)) {
+					String msg = r.getRule().getFullyQualifiedName() + "-{" + r.getRule().getExpression() + "}";
+					log.fine("matched: " + msg);
+				}
+				
 			}else{
-                if(log.isLoggable(Level.INFO)) log.info("unmatched: " + msg);
+                if(log.isLoggable(Level.FINE)) {
+					String msg = r.getRule().getFullyQualifiedName() + "-{" + r.getRule().getExpression() + "}";
+					log.fine("unmatched: " + msg);
+				}
 			}
 		}
 		

--- a/rules/src/main/java/ch/maxant/rules/Engine.java
+++ b/rules/src/main/java/ch/maxant/rules/Engine.java
@@ -93,7 +93,7 @@ public class Engine {
     /** static variable bindings to be used in addition to the input when executing rules */
     protected final Map<String, Object> statics;
 
-    private List<CompiledRule> rules;
+    protected List<CompiledRule> rules;
 	protected final Set<String> uniqueOutcomes = new HashSet<String>();
 	protected List<Rule> parsedRules;
 
@@ -457,7 +457,7 @@ public class Engine {
 		return matchingRules;
 	}
 	
-	private static final class CompiledRule {
+	protected static final class CompiledRule {
 		private Rule rule;
 		private Serializable compiled;
 		private CompiledRule(Rule rule) {


### PR DESCRIPTION
We have been using this awesome rules engine for almost 2 years thing have been great but recently we added more rule the performance started to degrade. We found that one improvement was to stop creating the log statement for every matched rule.

Second we found a use case where would would like to use more features of the MVEL sub system, and use the compiled rules and that are created in the Engine.java so adding the ability subclass the Engine.java would allow use to extend the functionality if needed. 

Resolves #7 